### PR TITLE
Add `dev` dependency group to `pyproject.toml`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,17 +13,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
 import pylipd
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-package_path = os.path.abspath('../..')
-os.environ['PYTHONPATH']=':'.join(((package_path), os.environ.get('PYTHONPATH','')))
-sys.path.insert(0,os.path.abspath('../pylipd'))
 autodoc_mock_imports = ["_tkinter"]
 # -- General configuration ------------------------------------------------
 

--- a/docs/contribution_guide.rst
+++ b/docs/contribution_guide.rst
@@ -73,9 +73,18 @@ At the command line, this would like something like::
 
 This creates the directory `pylipd-yourname` and connects your repository to the upstream (main project) PyLiPD repository.  However, most Git first-timers may find it easier to do so through the Github web interface or desktop app (where there is a proverbial “button for that”).
 
+.. _creating-a-development-environment:
+
 Creating a development environment
 """"""""""""""""""""""""""""""""""
-We recommend developing in the same conda environment in which you installed PyLiPD.
+
+Next create a development environment with the development dependencies, and an editable version of PyLiPD installed::
+
+    conda create --name pylipd-dev python=3.13
+    conda activate pylipd-dev
+    pip install --group dev --editable .
+
+This ensures that you will be able to run the tests and build the documentation with the code you edit in the branch you will create next.
 
 Creating a branch
 """""""""""""""""
@@ -232,7 +241,7 @@ This request then goes to the repository maintainers, and they will review the c
 Updating your pull request
 """"""""""""""""""""""""""
 
-Based on the review you get on your pull request, you will probably need to make some changes to the code. In that case, you can make them in your branch, add a new commit to that branch, push it to GitHub, and the pull request will be automatically updated. Pushing them to GitHub again is done by:
+Based on the review you get on your pull request, you will probably need to make some changes to the code. In that case, you can make them in your branch, add a new commit to that branch, push it to GitHub, and the pull request will be automatically updated. Pushing them to GitHub again is done by::
 
     git push origin shiny-new-feature
 
@@ -294,7 +303,7 @@ You may use existing docstrings as examples. A good docstring explains:
   * what it does, with what properties/inputs/outputs
   * how to use it, via a minimal working example.
 
-For the latter, make sure the example is prefaced by:
+For the latter, make sure the example is prefaced by::
 
       .. jupyter-execute::
 
@@ -303,7 +312,7 @@ and properly indented (look at other docstrings for inspiration).
 How to build the PyLiPD documentation
 """"""""""""""""""""""""""""""""""""""""
 
-Navigate to the docs folder and type `make html`. This may require installing other packages (sphinx, chardet, numpydoc, nbsphinx, sphinx_search, jupyter-sphinx, sphinx_copybutton, sphinx_rtd_theme).
+Navigate to the docs folder and type `make html`. If you have set up your development environment as in :ref:`creating-a-development-environment` you should not need to install any additional dependencies.
 
 
 You are done! Thanks for playing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,19 @@ dependencies = [
   "requests"
 ]
 
+[dependency-groups]
+dev = [
+  "IPython",
+  "jupyter-sphinx",
+  "nbsphinx",
+  "numpydoc>=1.1.0",
+  "readthedocs-sphinx-search>=0.1.0",
+  "pytest",
+  "Sphinx",
+  "sphinx-copybutton",
+  "sphinx-rtd-theme>=1.0.0"
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["pylipd*"]


### PR DESCRIPTION
This PR adds a `dev` dependency group to `pyproject.toml` that facilitates setting up a valid development environment, e.g. one can create an editable install with the appropriate dependencies using:

```
$ git clone https://github.com/LinkedEarth/pylipd.git
$ cd pylipd
$ conda create --name pylipd-dev python=3.13
$ conda activate pylipd-dev
$ pip install --group dev --editable .
```

The development dependencies I added were `pytest`, needed to run the tests, and the dependencies listed in `docs/rtd_env.yml`.  In this environment I was able to successfully run the tests and build the documentation, after slightly simplifying `conf.py` to remove some path-editing logic that resulted in circular imports within `jupyter-execute` blocks.

I updated the documentation with these instructions, and fixed a couple minor formatting issues as well.  It should hopefully make making contributions to the documentation in particular more straightforward to new developers.

xref: https://github.com/openjournals/joss-reviews/issues/8861