### PR TITLE
Silence warnings in test suite

### DIFF
--- a/pylipd/utils/lipd_to_rdf.py
+++ b/pylipd/utils/lipd_to_rdf.py
@@ -57,7 +57,7 @@ class LipdToRDF:
         self.graph = ConjunctiveGraph()
         
         lpdname = os.path.basename(lipdpath).replace(".lpd", "")
-        lpdname = re.sub("\?.+$", "", lpdname)
+        lpdname = re.sub(r"\?.+$", "", lpdname)
 
         self.graphurl = NSURL + "/" + lpdname
 
@@ -132,13 +132,13 @@ class LipdToRDF:
     def _parse_persons_string(self, author_string, parent = None) :
         # Check for semi-colon delimiter and split accordingly
         if ";" in author_string:
-            author_split = re.split("\s*;\s*", author_string)
+            author_split = re.split(r"\s*;\s*", author_string)
             # Further split the authors with commas if necessary
             author_list = []
             for author in author_split:
                 author = author
                 if "," in author:
-                    last_first = re.split("\s*,\s*", author)
+                    last_first = re.split(r"\s*,\s*", author)
                     author_list.append(f"{last_first[1]} {last_first[0]}")
                 else:
                     author_list.append(author)
@@ -146,7 +146,7 @@ class LipdToRDF:
         else:
             # Split the author string with commas
             author_list = []
-            author_split = re.split("\s*,\s*", author_string)
+            author_split = re.split(r"\s*,\s*", author_string)
             if len(author_split) % 2 == 0:
                 # Even number : last name first name
                 for i in range(0, len(author_split), 2):
@@ -971,7 +971,7 @@ class LipdToRDF:
                     self._set_property_value(objid, propDI, value)
 
     def _find_files_with_extension(self, directory, extension):
-        myregexobj = re.compile('\.'+extension+'$')
+        myregexobj = re.compile(r'\.'+extension+'$')
         try: 
             for entry in os.scandir(directory):
                 if entry.is_file() and myregexobj.search(entry.path): 


### PR DESCRIPTION
Running the tests produces over 1900 warnings:

```
==================================================================== warnings summary =====================================================================
../utils/lipd_to_rdf.py:60
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:60: SyntaxWarning: invalid escape sequence '\?'
    lpdname = re.sub("\?.+$", "", lpdname)

../utils/lipd_to_rdf.py:135
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:135: SyntaxWarning: invalid escape sequence '\s'
    author_split = re.split("\s*;\s*", author_string)

../utils/lipd_to_rdf.py:141
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:141: SyntaxWarning: invalid escape sequence '\s'
    last_first = re.split("\s*,\s*", author)

../utils/lipd_to_rdf.py:149
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:149: SyntaxWarning: invalid escape sequence '\s'
    author_split = re.split("\s*,\s*", author_string)

../utils/lipd_to_rdf.py:974
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:974: SyntaxWarning: invalid escape sequence '\.'
    myregexobj = re.compile('\.'+extension+'$')

pylipd/tests/test_LiPD.py: 58 warnings
pylipd/tests/test_LiPDClasses.py: 12 warnings
pylipd/tests/test_LiPDSeries.py: 192 warnings
  /Users/spencer/software/pylipd/pylipd/utils/rdf_graph.py:39: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    self.graph = ConjunctiveGraph()

pylipd/tests/test_LiPD.py: 353 warnings
pylipd/tests/test_LiPDClasses.py: 12 warnings
pylipd/tests/test_LiPDSeries.py: 162 warnings
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:38: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    self.graph = ConjunctiveGraph()

pylipd/tests/test_LiPD.py: 353 warnings
pylipd/tests/test_LiPDClasses.py: 12 warnings
pylipd/tests/test_LiPDSeries.py: 162 warnings
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:57: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    self.graph = ConjunctiveGraph()

pylipd/tests/test_LiPD.py: 353 warnings
pylipd/tests/test_LiPDClasses.py: 12 warnings
pylipd/tests/test_LiPDSeries.py: 162 warnings
  /Users/spencer/software/pylipd/pylipd/utils/lipd_to_rdf.py:985: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    self.graph = ConjunctiveGraph()

pylipd/tests/test_LiPD.py: 2 warnings
pylipd/tests/test_LiPDSeries.py: 54 warnings
  /Users/spencer/software/miniconda3/envs/pylipd-dev/lib/python3.13/copy.py:254: DeprecationWarning: ConjunctiveGraph is deprecated, use Dataset instead.
    y = func(*args)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 67 passed, 1904 warnings in 39.54s ============================================================
```

This PR addresses the `SyntaxWarning` cases, but for now leaves the more numerous `ConjunctiveGraph` deprecation warnings alone.  I am afraid I am not familiar enough to know whether simply switching from `ConjunctiveGraph` to `Dataset` as the deprecation warnings suggest would cause problems or not, but it would be nice to further cut down on these warnings if possible.

xref: https://github.com/openjournals/joss-reviews/issues/8861